### PR TITLE
Small refactor

### DIFF
--- a/app/css/main.css.scss
+++ b/app/css/main.css.scss
@@ -12,10 +12,13 @@
     "1.base",
     "2.layout",
     "3.helpers",
+
+    // Include your components here.
     "../components/button/button",
     "../components/docs-skeleton/docs-skeleton",
     "../components/hello-world/hello-world",
     "../components/tweet/tweet",
+
     "4.print",
     "5.states",
     "6.shame";

--- a/lib/grunt-tasks/sass.coffee
+++ b/lib/grunt-tasks/sass.coffee
@@ -1,9 +1,10 @@
 module.exports =
   options:
-    bundleExec: true
-    style: 'expanded'
-    require: 'sass-globbing'
-    includePaths: ['lib/bower_components', '<%= config.libDir %>/toolset/grunt-tasks/assembler', '<%= config.srcDir %>/css']
+    includePaths: [
+      'lib/bower_components',
+      '<%= config.libDir %>/toolset/grunt-tasks/assembler',
+      '<%= config.srcDir %>/css'
+    ]
   dev:
     files: [
       {


### PR DESCRIPTION
Removes bundle exec (only used by ruby-sass).
Removes style (in node-sass is outputStyle but the expanded is not yet supported) https://github.com/sass/node-sass#outputstyle
Removes inclusion of sass globbing (part of ruby sass).