### PR TITLE
Modifies the getClassModifier to return an array

### DIFF
--- a/app/components/helpers.jade.js
+++ b/app/components/helpers.jade.js
@@ -10,14 +10,14 @@ function setOptionsDefaults(options, componentName, component) {
 module.exports.setOptionsDefaults = setOptionsDefaults;
 
 function getOptionsModifier(options, componentName, filters, component) {
-  var classes = "" + componentName;
+  var classes = ["componentName"];
   if (filters) {
     for ( var index in filters) {
-      classes = classes + " " + getClassModifier(componentName, filters[index], options, component);
+      classes.push(getClassModifier(componentName, filters[index], options, component));
     }
   } else {
     for ( var key in component.options ) {
-      classes = classes + " " + getClassModifier(componentName, key, options, component);
+      classes.push(getClassModifier(componentName, key, options, component));
     }
   }
 

--- a/app/components/helpers.jade.js
+++ b/app/components/helpers.jade.js
@@ -10,7 +10,7 @@ function setOptionsDefaults(options, componentName, component) {
 module.exports.setOptionsDefaults = setOptionsDefaults;
 
 function getOptionsModifier(options, componentName, filters, component) {
-  var classes = ["componentName"];
+  var classes = [componentName];
   if (filters) {
     for ( var index in filters) {
       classes.push(getClassModifier(componentName, filters[index], options, component));


### PR DESCRIPTION
Jade allows to set classes from an array:

```
- var classes = ['class1', 'class2']

div(class=classes)
```

This is a better solution than a string because to add a class it's pretty easy:

```
- classes.push('anotherClass')
```