### PR TITLE
optimize styleguide compilation time

### DIFF
--- a/lib/toolset/grunt-tasks/assembler/helpers.js
+++ b/lib/toolset/grunt-tasks/assembler/helpers.js
@@ -27,9 +27,22 @@ Helper = (function() {
    * @return {String} file's html compiled with jade
    */
   Helper.prototype.jadeRender = function (file, vars, extraTpl) {
-    var tpl;
+    var tpl = this.jadeCompile(file, extraTpl);
     vars = _.merge(vars, this.getJadeFunctions());
 
+    try {
+        return tpl(vars || {});
+    } catch (e) {
+        grunt.fail.fatal('Render error in ' + file + "\n" + e);
+    }
+  };
+
+  /**
+   * Utility function that receives a filepath and returns a Jade function.
+   * @param  {String} filepath
+   * @return {Function} a jade template function
+   */
+  Helper.prototype.jadeCompile = function (file, extraTpl) {
     try {
         tpl = require('jade').compile(grunt.file.read(file) + extraTpl, {
             filename    : file,
@@ -37,14 +50,9 @@ Helper = (function() {
             basedir     : srcDir,
             compileDebug: true
         });
+        return tpl;
     } catch (e) {
         grunt.fail.fatal('Build error in ' + file + "\n" + e);
-    }
-
-    try {
-        return tpl(vars || {});
-    } catch (e) {
-        grunt.fail.fatal('Render error in ' + file + "\n" + e);
     }
   };
 

--- a/lib/toolset/grunt-tasks/assembler/styleguideAssembler.js
+++ b/lib/toolset/grunt-tasks/assembler/styleguideAssembler.js
@@ -19,7 +19,9 @@ module.exports = function (grunt, options) {
       templatesPath = "lib/toolset/grunt-tasks/assembler/styleguide-templates/s-pages/components/",
       componentListTemplate         = templatesPath + "component-list.jade",
       componentTemplate             = templatesPath + "component.jade",
-      componentCombinationTemplate  = templatesPath + "component-combination.jade";
+      componentCombinationTemplate  = templatesPath + "component-combination.jade",
+      tplComponentCombination       = Helper.jadeCompile(componentCombinationTemplate),
+      tplComponent                  = Helper.jadeCompile(componentTemplate);
 
   /**
    * Given an array of arrays, generates all possible combinations
@@ -129,34 +131,38 @@ module.exports = function (grunt, options) {
   }
 
   function generateComponentPage(component, componentsData) {
+    var jadeFunctions = Helper.getJadeFunctions();
+    var vars = {};
+
     if (!component.hideInStyleguide) {
       component.combinations = generateComponentOptionsCombinations(component);
 
       grunt.log.write("Creating component " + component.name + " combinations.");
+
       _.each(component.combinations, function (combination, index) {
         grunt.log.write(".");
-        var combinationHtml = Helper.jadeRender(
-          componentCombinationTemplate,
-          {
-            "component": component,
-            "components": componentsData.allMetadata,
-            "combination": combination,
-            "relativePath": "../../../"
-          }
-        );
+
+        vars = _.merge({
+          "component": component,
+          "components": componentsData.allMetadata,
+          "combination": combination,
+          "relativePath": "../../../"
+        }, jadeFunctions);
+
+        var combinationHtml = tplComponentCombination(vars);
         grunt.file.write("dist/styleguide/components/" + component.name + "/c" + index + ".html", combinationHtml);
         // grunt.log.writeln("combination html"+ combinationHtml);
       });
 
       grunt.log.writeln("\nCreating component " + component.name + " page...");
-      var componentHtml = Helper.jadeRender(
-        componentTemplate,
-        {
-          "component": component,
-          "components": componentsData.allMetadata,
-          "relativePath": "../../"
-        }
-      );
+
+      vars = _.merge({
+        "component": component,
+        "components": componentsData.allMetadata,
+        "relativePath": "../../"
+      }, jadeFunctions);
+
+      var componentHtml = tplComponent(vars);
       grunt.file.write("dist/styleguide/components/" + component.name + ".html", componentHtml);
     }
   }


### PR DESCRIPTION
Tried to move the Jade template compilation out of the generateComponentPage function.

- Template are compiled to javascript function only once at the beginning.
- Now in `generateComponentPage` we simply call the generated template function instead of compiling it.

These are the results with the basler project when running `grunt stylguide`:

before:

    Execution Time (2015-04-28 07:39:55 UTC)
    styleguideAssembler  2m 44.5s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 100%
    Total 2m 45.2s

after:

    Execution Time (2015-04-28 07:48:04 UTC)
    loading tasks         1.3s  ▇▇▇▇▇▇▇▇▇▇▇ 26%
    clean:dist            89ms  ▇ 2%
    copy:images          107ms  ▇ 2%
    styleguideAssembler   3.5s  ▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 69%
    Total 5s

