### PR TITLE
Fixes npm postinstall of bower on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "main": "dist/index.html",
   "scripts": {
-    "postinstall": "node_modules/bower/bin/bower install",
-    "postupdate": "node_modules/bower/bin/bower install"
+    "postinstall": "bower install",
+    "postupdate": "bower install"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Fixes #56 
The relative paths don't work as is not an app.
node_modules/bower/bin/bower.exe would be.

Looks like usually people just add bower install.
As bower is in the dependencies it's supposed to fallback to the local version.

havent's tried it though