### PR TITLE
Reloads the browser only once on jade changes

### DIFF
--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -5,7 +5,6 @@ var merge         = require('merge-stream');
 var path          = require('path');
 var pageshelpers  = require('../utils/pagesHelpers');
 var handleError   = require('../utils/handleError');
-var stream        = require('../utils/browserSync').stream;
 
 module.exports = function (gulp, $, config) {
   var srcFiles           = config.appFiles.pages;
@@ -73,6 +72,6 @@ module.exports = function (gulp, $, config) {
     // Generate the pages for each language
     var pagesStreams = languages.map(compilePages);
 
-    return merge(pagesStreams).pipe(stream());
+    return merge(pagesStreams);
   };
 };

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -1,5 +1,6 @@
 'use strict';
 var browserSync = require('../utils/browserSync');
+var reload      = browserSync.reload;
 var _           = require('lodash');
 
 module.exports = function (gulp, $, config) {
@@ -37,10 +38,10 @@ module.exports = function (gulp, $, config) {
     gulp.watch(stylesFiles, ['build:styles']);
 
     // Watching Pages
-    gulp.watch(pagesFiles, ['build:pages']);
+    gulp.watch(pagesFiles, ['build:pages', reload]);
 
     // Watching Content
-    gulp.watch(contentSrcFiles, ['build:pages']);
+    gulp.watch(contentSrcFiles, ['build:pages', reload]);
 
     // Watching Assets
     gulp.watch(logosFiles, ['build:assets']);

--- a/gulp/utils/browserSync.js
+++ b/gulp/utils/browserSync.js
@@ -14,5 +14,6 @@ module.exports = {
     }
   },
   notify: browserSync.notify,
-  stream: browserSync.stream
+  stream: browserSync.stream,
+  reload: browserSync.reload
 };


### PR DESCRIPTION
Before it was reloading as many time as you had jade pages.
Now the gulp watch reloads the server once the task is done.
I would have expected those to run in parallel but apparently gulp watch does those in sequence. So, yeah, it works. Yay.