### PR TITLE
Fixes the sensible version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,6 @@
   "name": "project-name",
   "private": true,
   "dependencies": {
-    "sensible": "~0.5.2"
+    "sensible": "0.5.2"
   }
 }


### PR DESCRIPTION
This is needed as long as sensible is below v1 as it gets breaking changes like [this one](https://github.com/meodai/sensible/commit/26f8789f6b361ab15489b6c38c1b880417773824).

The effect of those changes is that people end up with different version of the library that all match the ~0.5.2.
This leads to different built code on each commit from different people [like here](https://lejoe.s3.amazonaws.com/uploads/pb-wFTi43HOO8)