### PR TITLE
Jade inline helper

### DIFF
--- a/gulp/utils/pagesHelpers.js
+++ b/gulp/utils/pagesHelpers.js
@@ -2,6 +2,7 @@
 var yamljs      = require('yamljs');
 var _           = require('lodash');
 var markdown    = require('marked');
+var jadeInline  = require('jade-inline-file');
 
 module.exports = function (config) {
   var srcDir = config.basePaths.src;
@@ -101,6 +102,7 @@ module.exports = function (config) {
 
   return {
     mergeDefaultOptions: mergeDefaultOptions,
-    markdown: markdown
+    markdown: markdown,
+    inline: jadeInline
   };
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "postinstall": "node_modules/bower/bin/bower install",
     "postupdate": "node_modules/bower/bin/bower install"
   },
-  "dependencies": {},
   "devDependencies": {
     "bower": "^1.3.12",
     "browser-sync": "^2.6.5",
@@ -33,6 +32,7 @@
     "gulp-util": "^3.0.4",
     "jade": "^1.11.0",
     "jade-glob-include": "^1.0.1",
+    "jade-inline-file": "^0.1.0",
     "lodash": "^3.7.0",
     "marked": "^0.3.3",
     "merge-stream": "^0.1.7",


### PR DESCRIPTION
adds jade-inline-file helper. Can be used to inline SVG's for example