### PR TITLE
Fixes the relative path calculations

### DIFF
--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -30,8 +30,7 @@ module.exports = function (gulp, $, config) {
   var getRelativePath = function(file, language) {
     var destPath = config.paths.pages.src + getLanguagePath(language);
     var filePath = path.dirname(file.path);
-
-    return (path.relative(destPath, filePath) || '.') + '/';
+    return (path.relative(filePath, destPath) || '.') + '/';
   };
 
   var task = function () {


### PR DESCRIPTION
Here’s an example of the change:

Assume such a folder structure:
```
src/pages
|
`- index.html
|
`- A
  |
  `- A.html
    |
    `- B
      |
      `- B.html
```

## Before

`index.html`: `./`
`A/A.html`: `B/`
`A/B/B.html`: `A/B/`

## After
`index.html`: `./`
`A/A.html`: `../`
`A/B/B.html`: `../../`