### PR TITLE
makes sure its easier to mix classes with attributes

### DIFF
--- a/src/modules/card/layout.jade
+++ b/src/modules/card/layout.jade
@@ -17,7 +17,9 @@ mixin card(data, options)
   if options.float
     - classes.push('card--' + options.float);
 
-  div(class=classes)
+  - attributes.class = classes;
+
+  div&attributes(attributes)
     if data.background
       img(src=relativePath + data.background.image, alt=data.background.alt).card-background
     .l-absolute-centered.card-content


### PR DESCRIPTION
My adding the classes back to the attributes, it makes it easier to mix it with other attributes.

because if we use
```jade
div(class=classes)&attributes(attributes)
```
The class attribute will be rendered twice. Also by default it makes it easier to make other attributes dependant on options out of the box