### PR TITLE
Production build

### DIFF
--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -17,8 +17,8 @@ module.exports = (gulp, $, config) => {
       }))
       .pipe($.if(!config.isProd, $.sourcemaps.init()))
       .pipe($.sass({
-        includePaths : ['node_modules'],
-        outputStyle  : config.isProd ? 'compressed' : '',
+        includePaths: ['node_modules'],
+        outputStyle: config.isProd ? 'compressed' : '',
       }))
       .pipe($.autoprefixer({ browsers: ['last 2 versions', 'ie 9'] }))
       .pipe($.if(!config.isProd, $.sourcemaps.write({ includeContent: true })))

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -15,10 +15,13 @@ module.exports = (gulp, $, config) => {
       .pipe($.cssGlobbing({
         extensions: ['.scss'],
       }))
-      .pipe($.sourcemaps.init())
-      .pipe($.sass({ includePaths: ['node_modules'] }))
+      .pipe($.if(!config.isProd, $.sourcemaps.init()))
+      .pipe($.sass({
+        includePaths : ['node_modules'],
+        outputStyle  : config.isProd ? 'compressed' : '',
+      }))
       .pipe($.autoprefixer({ browsers: ['last 2 versions', 'ie 9'] }))
-      .pipe($.sourcemaps.write({ includeContent: true }))
+      .pipe($.if(!config.isProd, $.sourcemaps.write({ includeContent: true })))
       .pipe($.if(config.isProd, $.revReplace({
         manifest: fs.existsSync(manifestFile) && gulp.src(manifestFile),
       })))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,5 +52,30 @@ module.exports = config => ({
       name: 'vendor',
       filename: 'vendor.js',
     }),
-  ],
+
+  // Production-Only Plugins
+  // (they get concatenated only if we're building for production)
+  // See: https://webpack.js.org/guides/production-build/#the-manual-way-configuring-webpack-for-multiple-environments
+  ].concat(config.isProd ? [
+    new webpack.LoaderOptionsPlugin({
+      minimize : true,
+      debug    : false,
+    }),
+    new webpack.DefinePlugin({
+      'process.env' : {
+        NODE_ENV : JSON.stringify('production'),
+      },
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      beautify : false,
+      mangle   : {
+        screw_ie8   : true,
+        keep_fnames : true,
+      },
+      compress : {
+        screw_ie8 : true,
+      },
+      comments : false,
+    }),
+  ] : []),
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -58,24 +58,24 @@ module.exports = config => ({
   // See: https://webpack.js.org/guides/production-build/#the-manual-way-configuring-webpack-for-multiple-environments
   ].concat(config.isProd ? [
     new webpack.LoaderOptionsPlugin({
-      minimize : true,
-      debug    : false,
+      minimize: true,
+      debug: false,
     }),
     new webpack.DefinePlugin({
-      'process.env' : {
-        NODE_ENV : JSON.stringify('production'),
+      'process.env': {
+        NODE_ENV: JSON.stringify('production'),
       },
     }),
     new webpack.optimize.UglifyJsPlugin({
-      beautify : false,
-      mangle   : {
-        screw_ie8   : true,
-        keep_fnames : true,
+      beautify: false,
+      mangle: {
+        screw_ie8: true,
+        keep_fnames: true,
       },
-      compress : {
-        screw_ie8 : true,
+      compress: {
+        screw_ie8: true,
       },
-      comments : false,
+      comments: false,
     }),
   ] : []),
 });


### PR DESCRIPTION
## For JS:
- uses all the webpack configs described in https://webpack.js.org/guides/production-build/

## For CSS:
- compresses CSS (node-sass configuration)
- Removes sourcemaps from build.

## Before
<img width="691" alt="screen shot 2017-02-17 at 14 47 11" src="https://cloud.githubusercontent.com/assets/389459/23067567/37698ba8-f520-11e6-8e1e-087c886f7fc3.png">

## After
<img width="689" alt="screen shot 2017-02-17 at 14 47 29" src="https://cloud.githubusercontent.com/assets/389459/23067566/3755232a-f520-11e6-9b3b-226f72459fd1.png">