### PR TITLE
Faster pug builds

### DIFF
--- a/gulp/utils/pagesHelpers.js
+++ b/gulp/utils/pagesHelpers.js
@@ -1,11 +1,8 @@
-const yamljs = require('yamljs');
 const _ = require('lodash');
 const markdown = require('marked');
 const pugInline = require('jade-inline-file');
 
 module.exports = (config, mergedDefinitions) => {
-  const srcDir = config.basePaths.src;
-
   // TODO: Rewrite and document this helper function
 
   /**

--- a/gulp/utils/pagesHelpers.js
+++ b/gulp/utils/pagesHelpers.js
@@ -3,7 +3,7 @@ const _ = require('lodash');
 const markdown = require('marked');
 const pugInline = require('jade-inline-file');
 
-module.exports = (config) => {
+module.exports = (config, mergedDefinitions) => {
   const srcDir = config.basePaths.src;
 
   // TODO: Rewrite and document this helper function
@@ -86,7 +86,7 @@ module.exports = (config) => {
   //     '': value3
   //   border: true
   const mergeDefaultOptions = (options = {}, path) => {
-    const schema = yamljs.load(`${srcDir}${path}/definition.yml`);
+    const schema = mergedDefinitions[path];
     const optionsSchema = schema.options;
 
     return _.mapValues(optionsSchema, (o, oKey) => {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-airbnb-base": "^11.1.0",
     "eslint-config-es2015": "^1.1.0",
     "eslint-plugin-import": "^2.2.0",
+    "glob": "^7.1.1",
     "gulp": "gulpjs/gulp.git#4.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-changed": "^1.2.1",


### PR DESCRIPTION
I had an ha-ha moment on how to optimise pug performance.

In short, this optimises the performance of `mergeDefaulOptions` by removing the i/o call on every invocation. The required i/o call is now moved to gulp and only done 1/per module/per run (instead of 1/per mixin usage/per run).

Here's a test with 89% improvements in speed (from 18s to 2.11 s):

![screen shot 2017-02-17 at 15 10 32](https://cloud.githubusercontent.com/assets/389459/23068351/939e62d8-f523-11e6-9097-1b6572cc85d7.png)
![screen shot 2017-02-17 at 15 10 23](https://cloud.githubusercontent.com/assets/389459/23068350/939c117c-f523-11e6-8971-b43577397c3e.png)
![screen shot 2017-02-17 at 15 09 39](https://cloud.githubusercontent.com/assets/389459/23068349/939afe40-f523-11e6-8955-2fb0f52c72f1.png)
