### PR TITLE
Fix gulp handle error function

### DIFF
--- a/gulp/utils/handleError.js
+++ b/gulp/utils/handleError.js
@@ -1,9 +1,7 @@
 const gNotify = require('gulp-notify');
 const bsNotify = require('./browserSync').notify;
 
-module.exports = () => {
-  const args = Array.prototype.slice.call(arguments);
-
+module.exports = function notify(...args) {
   // Send error to the terminal with gulp-notify
   gNotify.onError({
     title: '<%= error.plugin %>',


### PR DESCRIPTION
Since it was using `this.emit` the fix was to convert from arrow function to function.

Also, this use the recommend rest operator instead of `arguments` following the `prefer-rest-params` eslint rule.

Now you can have an task error without breaking the gulp pipeline.