### PR TITLE
refactors gulp tasks config.

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -45,7 +45,7 @@ module.exports = () => {
 
   const entryPaths = {
     root: 'src/',
-    pages: 'src/pages',
+    pages: 'src/pages/',
     content: 'content/texts/',
   };
 

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -1,83 +1,70 @@
-const argv = require('yargs').argv;
-const path = require('path');
-
 module.exports = () => {
-  const basePaths = {
-    root: path.join(__dirname, '..'),
+  // where are the entry files of each type
+  // note that this is different from all files.
+  // e.g. /src/elements/button/style.scss
+  // is not an entry file for styles (meaning it shouldn't get compiled)
+  const entryGlobs = {
+    // this will be webpack entries
+    scripts: ['src/scripts/**/*.js'],
+    // this will be compiled as css files
+    styles: ['src/styles/**/*.scss'],
+    // this files will generate pages
+    pages: ['src/pages/**/*.pug'],
+    // this files will generate content files
+    content: ['content/texts/**/*.yml'],
+    assets: [
+      'src/materials/**/',
+      '!src/materials/**/*.{yml,scss,pug,js}',
+      'content/**/*',
+      '!content/texts/**/*',
+      '!content/texts'
+    ],
+    meta: ['src/meta/**/*'],
+    definitions: ['src/**/definition.yml'],
+    tooling: ['gulp/**/*.js', 'gulpfile.js', 'webpack.config.js']
+  };
+
+  // Watch globs, whenever this files change, run the corresponding type task.
+  // Note that this is different from the entryGlobs.
+  // e.g. /src/elements/button/style.scss
+  // needs to be watched, but is not an entry file.
+  //
+  // other example is definition files. even though they are not pages,
+  // when they change, they have influence on the final html.
+  const watchGlobs = {
+    scripts: ['src/**/*.js'],
+    styles: ['src/**/*.scss'],
+    pages: ['src/**/*.pug', 'src/**/*.yml'],
+    content: ['content/texts/**/*.yml'],
+    assets: [
+      'src/materials/**/',
+      'content/**/*',
+    ],
+    meta: ['src/meta/**/*']
+  };
+
+  const entryPaths = {
     src: 'src/',
-    content: 'content/',
-    assets: 'assets/',
-    dest: 'build/',
-    tmp: '.tmp/',
+    pages: 'src/pages',
+    content: 'content/texts/',
   };
 
-  const languages = ['en'];
-
-  const paths = {
-    scripts: {
-      src: `${basePaths.src}scripts/`,
-      dest: `${basePaths.dest}js/`,
-    },
-    styles: {
-      src: `${basePaths.src}styles/`,
-      dest: `${basePaths.dest}css/`,
-    },
-    content: {
-      src: `${basePaths.content}texts/`,
-      dest: `${basePaths.dest}content/`,
-    },
-    pages: {
-      src: `${basePaths.src}pages/`,
-      dest: basePaths.dest,
-    },
-    layouts: {
-      src: `${basePaths.src}layouts/`,
-    },
-    assets: {
-      src: [
-        `${basePaths.src}materials/icons/`,
-        `${basePaths.src}materials/fonts/`,
-        `${basePaths.src}materials/images/`,
-        `${basePaths.content}images/`
-      ],
-      dest: `${basePaths.dest}assets`,
-    },
-    meta: {
-      src: `${basePaths.src}meta/`,
-      dest: `${basePaths.dest}`,
-    },
-    revManifest: {
-      dest: `${basePaths.dest}rev-manifest.json`,
-    },
+  const destPaths = {
+    root: 'build/',
+    scripts: 'build/js/',
+    styles: 'build/css/',
+    pages: 'build/',
+    content: 'build/content/',
+    assets: 'build/assets',
+    meta: 'build',
+    revManifest: 'build/rev-manifest.json',
   };
-
-  const appFiles = {
-    scripts: `${paths.scripts.src}**/*.js`,
-    styles: `${paths.styles.src}**/*.scss`,
-    content: `${paths.content.src}**/*.yml`,
-    pages: `${paths.pages.src}**/*.pug`,
-    layouts: `${paths.layouts.src}**/*.pug`,
-    assets: paths.assets.src.map(folder => `${folder}**/*`),
-    meta: `${paths.meta.src}**/*`,
-  };
-
-  const components = [
-    `${basePaths.src}modules/`,
-    `${basePaths.src}elements/`,
-  ];
-
-  const gulpFiles = [
-    'gulp/**/*.js',
-    'gulpfile.js',
-  ];
 
   return {
-    basePaths,
-    languages,
-    paths,
-    appFiles,
-    components,
-    gulpFiles,
+    destPaths,
+    entryPaths,
+    entryGlobs,
+    watchGlobs,
     isProd: process.env.NODE_ENV === 'production',
   };
 };

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -44,7 +44,7 @@ module.exports = () => {
   };
 
   const entryPaths = {
-    src: 'src/',
+    root: 'src/',
     pages: 'src/pages',
     content: 'content/texts/',
   };

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -13,7 +13,7 @@ module.exports = () => {
     // this files will generate content files
     content: ['content/texts/**/*.yml'],
     assets: [
-      'src/materials/**/',
+      'src/materials/**/*',
       '!src/materials/**/*.{yml,scss,pug,js}',
       'content/**/*',
       '!content/texts/**/*',
@@ -37,7 +37,7 @@ module.exports = () => {
     pages: ['src/**/*.pug', 'src/**/*.yml'],
     content: ['content/texts/**/*.yml'],
     assets: [
-      'src/materials/**/',
+      'src/materials/**/*',
       'content/**/*',
     ],
     meta: ['src/meta/**/*']

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -66,5 +66,6 @@ module.exports = () => {
     entryGlobs,
     watchGlobs,
     isProd: process.env.NODE_ENV === 'production',
+    defaultLanguage: 'en'
   };
 };

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -55,8 +55,8 @@ module.exports = () => {
     styles: 'build/css/',
     pages: 'build/',
     content: 'build/content/',
-    assets: 'build/assets',
-    meta: 'build',
+    assets: 'build/assets/',
+    meta: 'build/',
     revManifest: 'build/rev-manifest.json',
   };
 

--- a/gulp/tasks/assets.js
+++ b/gulp/tasks/assets.js
@@ -1,16 +1,14 @@
-const path = require('path');
-
 module.exports = (gulp, $, config) => {
-  const assetsSrc = config.appFiles.assets;
-  const assetsDest = config.paths.assets.dest;
-  const manifestFile = config.paths.revManifest.dest;
+  const entryGlob = config.entryGlobs.assets;
+  const destPath = config.destPaths.assets;
+  const manifestPath = config.destPaths.revManifest;
 
-  const task = () => gulp.src(assetsSrc)
-      .pipe($.changed(assetsDest))
+  const task = () => gulp.src(entryGlob)
+      .pipe($.changed(destPath))
       .pipe($.if(config.isProd, $.rev()))
-      .pipe($.if(config.isProd, gulp.dest(assetsDest)))
-      .pipe($.if(config.isProd, $.rev.manifest(manifestFile, { merge: true, base: assetsDest })))
-      .pipe(gulp.dest(assetsDest))
+      .pipe($.if(config.isProd, gulp.dest(destPath)))
+      .pipe($.if(config.isProd, $.rev.manifest(manifestPath, { merge: true, base: destPath })))
+      .pipe(gulp.dest(destPath))
       ;
 
   task.description = 'Moves all the assets to the build. While on production, also revs the assets.';

--- a/gulp/tasks/clean.js
+++ b/gulp/tasks/clean.js
@@ -1,9 +1,7 @@
 const del = require('del');
 
 module.exports = (gulp, $, config) => {
-  const destFolder = `${config.basePaths.dest}*`;
-
-  const task = () => del([destFolder]);
+  const task = () => del(config.destPaths.root);
 
   task.description = 'Cleans the build folder';
   return task;

--- a/gulp/tasks/content.js
+++ b/gulp/tasks/content.js
@@ -1,18 +1,20 @@
 const merge = require('merge-stream');
+const configHelpers = require('../utils/configHelpers');
 
 module.exports = (gulp, $, config) => {
-  const srcFiles = config.paths.content.src;
-  const languages = config.languages;
-  const destFiles = config.paths.content.dest;
+  const entryPath = config.entryPaths.content;
+  const destPath = config.destPaths.content;
 
   const task = () => {
+    const languages = configHelpers.getAvailableLanguages(config);
+
     // Generate the language file for each language
     // eslint-disable-next-line arrow-body-style
     const contentStreams = languages.map((language) => {
-      return gulp.src(`${srcFiles}${language}/**/*.yml`)
+      return gulp.src(`${entryPath}${language}/**/*.yml`)
         .pipe($.concat(`${language}.yml`))
         // TODO: warn when there is a duplicate key
-        .pipe(gulp.dest(destFiles))
+        .pipe(gulp.dest(destPath))
         ;
     });
 

--- a/gulp/tasks/meta.js
+++ b/gulp/tasks/meta.js
@@ -1,10 +1,10 @@
 module.exports = (gulp, $, config) => {
-  const metaSrc = config.appFiles.meta;
-  const metaDest = config.paths.meta.dest;
+  const entryGlob = config.entryGlobs.meta;
+  const destPath = config.destPaths.meta;
 
-  const task = () => gulp.src(metaSrc)
-      .pipe($.changed(metaSrc))
-      .pipe(gulp.dest(metaDest))
+  const task = () => gulp.src(entryGlob)
+      .pipe($.changed(destPath))
+      .pipe(gulp.dest(destPath))
       ;
 
   task.description = 'Moves all the meta files to the build';

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -41,7 +41,7 @@ module.exports = (gulp, $, config) => {
         .reduce((a, b) => a.concat(b), [])
         .reduce((acc, definitionPath) => {
           const normalizedPath = definitionPath
-            .replace(config.entryPaths.src, '')
+            .replace(config.entryPaths.root, '')
             .replace('/definition.yml', '')
             ;
           return _.merge(acc, {

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -15,7 +15,7 @@ module.exports = (gulp, $, config) => {
   const contentPath = config.destPaths.content;
   const definitionGlob = config.entryGlobs.definitions;
   const manifestDestPath = config.destPaths.revManifest;
-  const defaultLanguage = config.defaultLanguage;
+  let defaultLanguage = config.defaultLanguage;
 
   // Load the content for the page
   function loadContentForLanguage(language) {
@@ -24,6 +24,11 @@ module.exports = (gulp, $, config) => {
 
   const task = () => {
     const languages = configHelpers.getAvailableLanguages(config);
+
+    if (!defaultLanguage && languages.length > 1) {
+      console.warn('There is more than one language defined. Consider adding a defaultLanguage on gulp/config.js. Alternatively, configure your server so it handles the root path of the project.');
+      defaultLanguage = languages[0];
+    }
 
     function getDestPath(language) {
       return destPath + configHelpers.getLanguagePath(language, languages, defaultLanguage);

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -29,11 +29,14 @@ module.exports = (gulp, $, config) => {
     }
 
     // Returns the relative path between the page and the root of the web server
-    const getRelativePath = (file, language) => {
-      const languageDestPath = config.entryPaths.pages +
-        configHelpers.getLanguagePath(language, languages);
-      const filePath = path.dirname(file.path);
-      return `${path.relative(filePath, languageDestPath) || '.'}/`;
+    const getRootPathFromPage = (file, language) => {
+      // e.g.: /src/pages
+      const originalPath = path.dirname(file.path);
+      // e.g.: /src/pages/en
+      const finalPath = `${originalPath}/${configHelpers.getLanguagePath(language, languages)}`;
+
+      // e.g.: ..
+      return path.relative(finalPath, originalPath);
     };
 
     function loadMergedDefinitions() {
@@ -60,7 +63,7 @@ module.exports = (gulp, $, config) => {
           const mergedDefinitions = loadMergedDefinitions();
           return {
             data: loadContentForLanguage(language),
-            relativePath: getRelativePath(file, language),
+            relativePath: getRootPathFromPage(file, language),
             helpers: pageshelpers(config, mergedDefinitions),
             language,
           };

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -42,7 +42,11 @@ module.exports = (gulp, $, config) => {
       const finalPath = `${originalPath}/${configHelpers.getLanguagePath(language, languages, defaultLanguage)}`;
 
       // e.g.: ..
-      return path.relative(finalPath, originalPath);
+      const relativePath = path.relative(finalPath, originalPath);
+
+      // "" --> ""
+      // ".." --> "../"
+      return relativePath ? `${relativePath}/` : relativePath;
     };
 
     function loadMergedDefinitions() {

--- a/gulp/tasks/pages.js
+++ b/gulp/tasks/pages.js
@@ -15,6 +15,7 @@ module.exports = (gulp, $, config) => {
   const contentPath = config.destPaths.content;
   const definitionGlob = config.entryGlobs.definitions;
   const manifestDestPath = config.destPaths.revManifest;
+  const defaultLanguage = config.defaultLanguage;
 
   // Load the content for the page
   function loadContentForLanguage(language) {
@@ -25,7 +26,7 @@ module.exports = (gulp, $, config) => {
     const languages = configHelpers.getAvailableLanguages(config);
 
     function getDestPath(language) {
-      return destPath + configHelpers.getLanguagePath(language, languages);
+      return destPath + configHelpers.getLanguagePath(language, languages, defaultLanguage);
     }
 
     // Returns the relative path between the page and the root of the web server
@@ -33,7 +34,7 @@ module.exports = (gulp, $, config) => {
       // e.g.: /src/pages
       const originalPath = path.dirname(file.path);
       // e.g.: /src/pages/en
-      const finalPath = `${originalPath}/${configHelpers.getLanguagePath(language, languages)}`;
+      const finalPath = `${originalPath}/${configHelpers.getLanguagePath(language, languages, defaultLanguage)}`;
 
       // e.g.: ..
       return path.relative(finalPath, originalPath);

--- a/gulp/tasks/scripts.js
+++ b/gulp/tasks/scripts.js
@@ -5,19 +5,19 @@ const gulpWebpack = require('webpack-stream');
 const webpackConfig = require('../../webpack.config');
 
 module.exports = (gulp, $, config) => {
-  const scriptsFiles = config.appFiles.scripts;
-  const destPath = config.paths.scripts.dest;
-  const manifestFile = config.paths.revManifest.dest;
+  const entryGlob = config.entryGlobs.scripts;
+  const destPath = config.destPaths.scripts;
+  const manifestDestPath = config.destPaths.revManifest;
 
   const task = () =>
-    gulp.src(scriptsFiles)
+    gulp.src(entryGlob)
       .pipe($.plumber(handleError))
       .pipe($.eslint())
       .pipe($.eslint.format())
       .pipe(gulpWebpack(webpackConfig(config), webpack))
       .pipe($.if(config.isProd, $.rev()))
       .pipe($.if(config.isProd, gulp.dest(destPath)))
-      .pipe($.if(config.isProd, $.rev.manifest(manifestFile, {
+      .pipe($.if(config.isProd, $.rev.manifest(manifestDestPath, {
         merge: true,
         base: destPath,
       })))

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -1,45 +1,20 @@
-const _ = require('lodash');
 const browserSync = require('../utils/browserSync');
 
 const reload = browserSync.reload;
 
 // eslint-disable-next-line max-statements
 module.exports = (gulp, $, config) => {
-  const serverBase = config.basePaths.dest;
-  const scriptFiles = [config.appFiles.scripts];
-  const stylesFiles = [config.appFiles.styles];
-  const pagesFiles = [config.appFiles.pages, config.appFiles.layouts];
-  const contentSrcFiles = config.appFiles.content;
-  const assetsFiles = config.appFiles.assets;
-  const componentsDirs = config.components;
-  const metaFiles = config.appFiles.meta;
-
-  _.map(componentsDirs, componentDir => scriptFiles.push(`${componentDir}**/*.js`));
-  _.map(componentsDirs, componentDir => stylesFiles.push(`${componentDir}**/*.scss`));
-  _.map(componentsDirs, componentDir => pagesFiles.push(`${componentDir}**/*.pug`));
-  _.map(componentsDirs, componentDir => pagesFiles.push(`${componentDir}**/*.yml`));
-
   const task = () => {
     // Initialising the server
-    browserSync.start(serverBase);
+    browserSync.start(config.destPaths.root);
 
-    // Watching Scripts
-    gulp.watch(scriptFiles, gulp.parallel('build:scripts'));
-
-    // Watching Styles
-    gulp.watch(stylesFiles, gulp.parallel('build:styles'));
-
-    // Watching Pages
-    gulp.watch(pagesFiles, gulp.series('build:pages', reload));
-
-    // Watching Content
-    gulp.watch(contentSrcFiles, gulp.series('build:content', 'build:pages', reload));
-
-    // Watching Assets
-    gulp.watch(assetsFiles, gulp.parallel('build:assets'));
-
-    // Watching Meta
-    gulp.watch(metaFiles, gulp.parallel('build:meta'));
+    // Start watching processes
+    gulp.watch(config.watchGlobs.scripts, gulp.parallel('build:scripts'));
+    gulp.watch(config.watchGlobs.styles, gulp.parallel('build:styles'));
+    gulp.watch(config.watchGlobs.pages, gulp.series('build:pages', reload));
+    gulp.watch(config.watchGlobs.content, gulp.series('build:content', 'build:pages', reload));
+    gulp.watch(config.watchGlobs.assets, gulp.parallel('build:assets'));
+    gulp.watch(config.watchGlobs.meta, gulp.parallel('build:meta'));
   };
 
   task.description = 'Serve the build folder';

--- a/gulp/tasks/styles.js
+++ b/gulp/tasks/styles.js
@@ -3,14 +3,14 @@ const stream = require('../utils/browserSync').stream;
 const handleError = require('../utils/handleError');
 
 module.exports = (gulp, $, config) => {
-  const srcFiles = config.appFiles.styles;
-  const destFiles = config.paths.styles.dest;
+  const entryGlobs = config.entryGlobs.styles;
+  const destPath = config.destPaths.styles;
   // previously rev files such as assets that might have been referenced
   // in the styles (and their path needs to be updated)
-  const manifestFile = config.paths.revManifest.dest;
+  const manifestDestPath = config.destPaths.revManifest;
 
   const task = () =>
-    gulp.src(srcFiles)
+    gulp.src(entryGlobs)
       .pipe($.plumber(handleError))
       .pipe($.sassGlob())
       .pipe($.if(!config.isProd, $.sourcemaps.init()))
@@ -21,15 +21,15 @@ module.exports = (gulp, $, config) => {
       .pipe($.autoprefixer({ browsers: ['last 2 versions', 'ie 9'] }))
       .pipe($.if(!config.isProd, $.sourcemaps.write({ includeContent: true })))
       .pipe($.if(config.isProd, $.revReplace({
-        manifest: fs.existsSync(manifestFile) && gulp.src(manifestFile),
+        manifest: fs.existsSync(manifestDestPath) && gulp.src(manifestDestPath),
       })))
       .pipe($.if(config.isProd, $.rev()))
-      .pipe($.if(config.isProd, gulp.dest(destFiles)))
-      .pipe($.if(config.isProd, $.rev.manifest(manifestFile, {
+      .pipe($.if(config.isProd, gulp.dest(destPath)))
+      .pipe($.if(config.isProd, $.rev.manifest(manifestDestPath, {
         merge: true,
-        base: destFiles,
+        base: destPath,
       })))
-      .pipe(gulp.dest(destFiles))
+      .pipe(gulp.dest(destPath))
       .pipe(stream({ match: '**/*.css' }))
       ;
 

--- a/gulp/tasks/tooling.js
+++ b/gulp/tasks/tooling.js
@@ -1,12 +1,12 @@
 module.exports = (gulp, $, config) => {
-  const gulpFiles = config.gulpFiles;
+  const entryGlobs = config.watchGlobs.tooling;
 
   const task = () =>
-    gulp.src(gulpFiles)
+    gulp.src(entryGlobs)
       .pipe($.eslint())
       .pipe($.eslint.format())
       ;
 
-  task.description = 'Lints the gulp tasks';
+  task.description = 'Lints the tooling files.';
   return task;
 };

--- a/gulp/utils/configHelpers.js
+++ b/gulp/utils/configHelpers.js
@@ -1,0 +1,22 @@
+const glob = require('glob');
+
+module.exports = {
+  getAvailableLanguages: (config) => {
+    const entry = config.entryGlobs.content;
+    const entryPath = config.entryPaths.content;
+    return entry.map(e => glob.sync(e))
+      .reduce((a, b) => a.concat(b), [])
+      .map((path) => {
+        const withoutBase = path.replace(entryPath, '');
+        return withoutBase.slice(0, withoutBase.indexOf('/'));
+      });
+  },
+
+  // Put the default language at the root
+  getLanguagePath: (language, languages) => {
+    if (language === languages[0]) {
+      return '';
+    }
+    return `${language}/`;
+  }
+};

--- a/gulp/utils/configHelpers.js
+++ b/gulp/utils/configHelpers.js
@@ -7,10 +7,17 @@ module.exports = {
   },
 
   // Put the default language at the root
-  getLanguagePath: (language, languages) => {
+  getLanguagePath: (language, languages, defaultLanguage) => {
+    // put files on root if there is only 1 language
     if (languages.length === 1) {
       return '';
     }
+
+    // put the defaultLanguage pages on the root
+    if (language === defaultLanguage) {
+      return '';
+    }
+
     return `${language}/`;
   }
 };

--- a/gulp/utils/configHelpers.js
+++ b/gulp/utils/configHelpers.js
@@ -8,7 +8,7 @@ module.exports = {
 
   // Put the default language at the root
   getLanguagePath: (language, languages) => {
-    if (language === languages[0]) {
+    if (languages.lenght === 1) {
       return '';
     }
     return `${language}/`;

--- a/gulp/utils/configHelpers.js
+++ b/gulp/utils/configHelpers.js
@@ -2,14 +2,8 @@ const glob = require('glob');
 
 module.exports = {
   getAvailableLanguages: (config) => {
-    const entry = config.entryGlobs.content;
     const entryPath = config.entryPaths.content;
-    return entry.map(e => glob.sync(e))
-      .reduce((a, b) => a.concat(b), [])
-      .map((path) => {
-        const withoutBase = path.replace(entryPath, '');
-        return withoutBase.slice(0, withoutBase.indexOf('/'));
-      });
+    return glob.sync('*', { cwd: entryPath });
   },
 
   // Put the default language at the root

--- a/gulp/utils/configHelpers.js
+++ b/gulp/utils/configHelpers.js
@@ -8,7 +8,7 @@ module.exports = {
 
   // Put the default language at the root
   getLanguagePath: (language, languages) => {
-    if (languages.lenght === 1) {
+    if (languages.length === 1) {
       return '';
     }
     return `${language}/`;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('clean', t.getTask('clean'));
 
 // Moves all the assets to the build. While on production, also revs the assets.
 gulp.task('build:assets', t.getTask('assets'));
-
+//
 // Moves all the meta files to the build
 gulp.task('build:meta', t.getTask('meta'));
 
@@ -53,8 +53,8 @@ gulp.task(
 // Serve the build folder
 gulp.task('serve', t.getTask('serve'));
 
-// Lints the gulp tasks
-gulp.task('tasks', t.getTask('tasks'));
+// Lints the tooling files.
+gulp.task('tooling', t.getTask('tooling'));
 
 // What happens when just running 'gulp'
 gulp.task(

--- a/src/layouts/default.pug
+++ b/src/layouts/default.pug
@@ -16,5 +16,5 @@ html(lang=language)
     block body
 
 
-    script(src=relativePath + '/js/vendor.js')
-    script(src=relativePath + '/js/main.js')
+    script(src=relativePath + 'js/vendor.js')
+    script(src=relativePath + 'js/main.js')

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,10 @@ module.exports = config => ({
   // Here the application starts executing
   // and webpack starts bundling
   // can be string | object {entryname: entrypath} | array
-  // we are using an object here (result of `globEntries`)
-  entry: globEntries(config.appFiles.scripts),
+  // we are using an object here (merged result of `globEntries` for each entry glob)
+  entry: config.entryGlobs.scripts
+    .map(globEntries)
+    .reduce((a, b) => Object.assign({}, a, b), {}),
 
   // options related to how webpack emits results
   output: {


### PR DESCRIPTION
This PR refactors the config.js.

# Globs naming
Globs are now named globs and are always arrays. This makes it easy to add exclusion globs to `gulp.src`. Paths are paths (either files or folder)s.

# Less exports
Languages are now automatically "calculated". No need for them to be hardcoded on the config.

# Entry vs Watch Globs
I noticed a pattern where we have entry globs and watch globs. For example:
- `src/elements/button/style.scss` is in the style watch glob but not on the entry glob (in other words, it doesn't get compiled as a css file).
- `src/elements/button/scripts.js` is in the style watch glob but not on the entry glob (in other words, it isn't a webpack entry chunk).
- `src/elements/button/template.pug` or `src/elements/button/definition.yml` are both on the pages watch glob but is not both aren't in pages entry glob.

I also removed string concatenation, as I think it makes the code far readable (we don't have to scroll up to "decode" the glob). We can still easily rename things with FIND + REPLACE, but we don't compromise on readability.


# Extensability

It is now far easier to change skeleton defaults. For example, if one wanted to remove the `/scripts` folder and instead have layout/page specific styles (*cof* #118), it will only be needed to change one line: scripts entryGlob. Everything else adjusts accordingly. Same for javascript files.